### PR TITLE
Making the current input value an object property by the blur handler

### DIFF
--- a/js/tagit.js
+++ b/js/tagit.js
@@ -133,10 +133,11 @@
 
             //setup blur handler
             this.input.blur(function(e) {
-                var v = $(this).val();
+                self.currentValue = $(this).val();
                 if(self.options.allowNewTags) {
                     self.timer = setTimeout(function(){
-                        self._addTag(v);
+                        self._addTag(self.currentValue);
+                        self.currentValue = '';
                     }, 400);
                 }
                 $(this).val('');


### PR DESCRIPTION
Making the current input value an object property when the blur handler is triggered. This way the value is available to any other handlers for processing before the timer defined in the blur handler does, for example on form submit.

The issue I had is that the current value will not get set on form submit because of the timer not completing the _addTag call. With the last value as an object property I can now do the following on submit button click:

``` javascript
_init: function() {
    var self = this;

    $(document).ready(function(){
        $(self.element).closest('form').find(':submit').click(function() {
            if (self.currentValue) {
                self._addTag(self.currentValue);
            }
            self.currentValue = '';
            return true;
        });
    });
},
```
