### PR TITLE
fix for issue #8

### DIFF
--- a/js/tagit.js
+++ b/js/tagit.js
@@ -120,7 +120,7 @@
             }
             var inputBox = this.input;
             this.options.focus = function(event, ui) {
-            	if (ui.item.label !== undefined) {
+            	if (ui.item.label !== undefined && /^key/.test(event.originalEvent.type)) {
             		inputBox.val(ui.item.label);
             		inputBox.attr('tagValue', ui.item.value);
             		return false;


### PR DESCRIPTION
make options.autoFocus compatible (this is the method jquery-ui-autocomplete uses)

simply pass in the options.autoFocus (from jquery-ui-autocomplete) and it should work.
