### PR TITLE
Reset the tags

### DIFF
--- a/js/tagit.js
+++ b/js/tagit.js
@@ -73,7 +73,10 @@
 
             //add any initial tags added through html to the array
             this.element.children('li').each(function() {
-                self.options.initialTags.push($(this).text());
+            	var tagValue = $(this).attr('tagValue');
+                self.options.initialTags.push(
+                	tagValue ? {label: $(this).text(), value: tagValue} : $(this).text()
+                );
             });
 
             //add the html input


### PR DESCRIPTION
The user can call tagIt("reset") to clear the tags field to the initial tags (or empty if there are no initial tags). This is useful when you need to call form.reset(), which does not clear out the selected tags.
