### PR TITLE
Siblings/next bug

### DIFF
--- a/js/tagit.js
+++ b/js/tagit.js
@@ -173,7 +173,7 @@
 
             if (this.options.select) {
                 this.element.after('<select class="tagit-hiddenSelect" name="'+this.element.attr('name')+'" multiple="multiple"></select>');
-                this.select = this.element.siblings('.tagit-hiddenSelect');
+                this.select = this.element.next('.tagit-hiddenSelect');
             }
             this._initialTags();
 


### PR DESCRIPTION
Fix a bug, where two sibling tag fields with select enabled would interfere with each other.
Siblings() returns a set of all siblings matching the selector around the UL. But we always create the SELECT immediately after the UL, so we can just use next() to select the immediate sibling matching the selector. Otherwise, both selects may end up being updated when one of the tag fields is used.
