### PR TITLE
Added maxTags and maxLength options

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
             $('#demo2').tagit({tagSource: availableTags});
             $('#demo3').tagit({tagSource: availableTags, triggerKeys: ['enter', 'comma', 'tab']});
             $('#demo4').tagit({tagSource: availableTags, tagsChanged: function(a,b){$('#demo4Out').html(a + ' was ' + b); } });
+            $('#demo5').tagit({maxLength: 5, maxTags: 5 });
 
 
             $('#demo1GetTags').click(function(){showTags($('#demo1').tagit('tags'))});
@@ -48,6 +49,7 @@
 
             $('#demo3GetTags').click(function(){showTags($('#demo3').tagit('tags'))});
             $('#demo4GetTags').click(function(){showTags($('#demo4').tagit('tags'))});
+            $('#demo5GetTags').click(function(){showTags($('#demo5').tagit('tags'))});
 
             function showTags(tags){
                 var string = "Tags\r\n";
@@ -212,6 +214,26 @@
                 </td>
               </tr>              
 
+           <tr class="odd">
+                <td>maxLength</td>
+                <td>int</td>
+                <td><em>unlimited</em></td>
+                <td class="left">
+                  The maximum allowable length of a tab.<br/>
+                  If omitted, tags of unlimited length are allowed.
+                </td>
+              </tr>
+
+           <tr class="even">
+                <td>maxTags</td>
+                <td>int</td>
+                <td><em>unlimited</em></td>
+                <td class="left">
+                    The maximum number of tags that the user can enter.<br/>
+                    If omitted, an unlimited number of tags are allowed.
+                </td>
+              </tr>              
+
             </tbody>
         </table>
     </div>
@@ -299,6 +321,16 @@
             <p>Action:
             <div id="demo4Out">none</div>
             <p>
+        </div>
+
+        <h3>Limits</h3>
+
+        <div class="box">
+            <ul id="demo5"></ul>
+            <div class="buttons">
+                <button id="demo5GetTags" value="Get Tags">Get Tags</button>
+            </div>
+            <p>Maximum of 5 tags and 5 characters per tag.</p>
         </div>
     </div>
 

--- a/index.php
+++ b/index.php
@@ -42,6 +42,7 @@
             $('#demo2').tagit({tagSource: availableTags});
             $('#demo3').tagit({tagSource: availableTags, triggerKeys: ['enter', 'comma', 'tab']});
             $('#demo4').tagit({tagSource: availableTags, tagsChanged: function(a,b){$('#demo4Out').html(a + ' was ' + b); } });
+            $('#demo5').tagit({maxLength: 5, maxTags: 5 });
 
 
             $('#demo1GetTags').click(function(){showTags($('#demo1').tagit('tags'))});
@@ -49,6 +50,7 @@
             $('#demo2ResetTags').click(function(){$('#demo2').tagit('reset')});
             $('#demo3GetTags').click(function(){showTags($('#demo3').tagit('tags'))});
             $('#demo4GetTags').click(function(){showTags($('#demo4').tagit('tags'))});
+            $('#demo5GetTags').click(function(){showTags($('#demo5').tagit('tags'))});
 
             function showTags(tags){
                 var string = "Tags\r\n";
@@ -211,7 +213,26 @@
                     If null, the highlight effect is turned off.
                 </td>
               </tr>  
-              
+            
+              <tr class="odd">
+                   <td>maxLength</td>
+                   <td>int</td>
+                   <td><em>unlimited</em></td>
+                   <td class="left">
+                     The maximum allowable length of a tab.<br/>
+                     If omitted, tags of unlimited length are allowed.
+                   </td>
+                 </tr>
+
+              <tr class="even">
+                   <td>maxTags</td>
+                   <td>int</td>
+                   <td><em>unlimited</em></td>
+                   <td class="left">
+                       The maximum number of tags that the user can enter.<br/>
+                       If omitted, an unlimited number of tags are allowed.
+                   </td>
+                 </tr>              
             </tbody>
         </table>
     </div>
@@ -307,6 +328,16 @@
             <div id="demo4Out">none</div>
             <p>
         </div>
+        
+        <h3>Limits</h3>
+
+        <div class="box">
+            <ul id="demo5"></ul>
+            <div class="buttons">
+                <button id="demo5GetTags" value="Get Tags">Get Tags</button>
+            </div>
+            <p>Maximum of 5 tags and 5 characters per tag.</p>
+        </div>        
     </div>
 
     <h2> </h2>

--- a/js/tagit.js
+++ b/js/tagit.js
@@ -40,6 +40,10 @@
  * * Number 06
  * * Feature: added fill method
  * * Name: Shawn Wildermuth <wildermuth.com>
+ * --
+ * * Number 07
+ * * Feature: added maxLength and maxTags options
+ * * Name: Jeff Shantz <jeffshantz.com>
  */
 
 (function($) {
@@ -149,20 +153,24 @@
 
             //setup keydown handler
             this.input.keydown(function(e) {
+
                 var lastLi = self.element.children(".tagit-choice:last");
                 if (e.which == self._keys.backspace)
                     return self._backspace(lastLi);
 
                 if (self._isInitKey(e.which)) {
                     e.preventDefault();
-                    if (self.options.allowNewTags && $(this).val().length >= self.options.minLength) {
-                        self._addTag($(this).val());
-                   	} 
-                   	else if (!self.options.allowNewTags){
+					if (!self.options.allowNewTags || (self.options.maxTags !== undefined && self.tagsArray.length == self.options.maxTags)) {
                    	    self.input.val("");
+                   	}
+                    else if (self.options.allowNewTags && $(this).val().length >= self.options.minLength) {
+                        self._addTag($(this).val());
                    	}
                 }
                 
+				if (self.options.maxLength !== undefined && self.input.val().length == self.options.maxLength) {
+					e.preventDefault();
+				}
                 if (lastLi.hasClass('selected'))
                     lastLi.removeClass('selected');
                 


### PR DESCRIPTION
I had the need to limit the number of characters in a given tag, as well as limit the number of tags that the user can enter.  I have implemented this functionality in the `maxLength` and `maxTags` options, updated the documentation, and added a demo of this functionality in `index.html` and `index.php`.  Sample usage:

``` javascript
// Limit tag length to 5 characters, and allow only 5 tags in total
$('#tags').tagit({
     maxLength: 5, 
     maxTags: 5
});
```
