### PR TITLE
Removing a tag always internally removes the last tag, regardless of which was clicked

### DIFF
--- a/js/tagit.js
+++ b/js/tagit.js
@@ -241,7 +241,13 @@
             } else {
             	var index;
             	if (value === undefined) {
-            		index = $.inArray(label, this.tagsArray);
+            		index = -1;
+                    $.each(this.tagsArray, function (tagIndex, tag) {
+                      if (tag.label == label) {
+                        index = tagIndex;
+                        return false;
+                      }
+                    });
             		index = (index == -1 ? this.tagsArray.length - 1 : index);
             	} else {
             		index = this.tagsArray.length - 1;


### PR DESCRIPTION
_popTag always removes the last tag, as it uses $.inArray to search this.tagsArray for the index of the tag to remove. The problem is that it is searching by tag label, while the elements of tagsArray are objects in the form { label: '', value: '' }. So $.inArray never matches, which defaults _popTag to removing the last element. Then, when getting tags using .tagit('tags'), the tags returned may not match what is shown by the UI.

This change updates the code used to search tagsArray for the tag to be removed.
