### PR TITLE
use autoFocus option in autocomplete if allowNewTags is false

### DIFF
--- a/js/tagit.js
+++ b/js/tagit.js
@@ -147,7 +147,8 @@
             		inputBox.attr('tagValue', ui.item.value);
             		return false;
             	}
-            }
+            };
+            this.options.autoFocus = !this.options.allowNewTags;
             this.input.autocomplete(this.options);
             this.options.select = os;
 


### PR DESCRIPTION
This fixes issue #8 for me, which doesn't seem to be fixed by the pull request in #12.

If allowNewTags is false, then it the autocomplete should use the autoFocus option, to avoid having to press the down arrow to select an option. If my suggestion isn't the best way, then there should be some other way to set autoFocus for the autocomplete, perhaps by having an autoFocus option for tagit that gets passed on to autocomplete.
