### PR TITLE
allow using data- attributes instead of nonstandard "name" & "tagValue"

### DIFF
--- a/js/tagit.js
+++ b/js/tagit.js
@@ -86,7 +86,7 @@
 
             //add any initial tags added through html to the array
             this.element.children('li').each(function() {
-            	var tagValue = $(this).attr('tagValue');
+            	var tagValue = $(this).attr('tagValue') || $(this).data('value');
                 self.options.initialTags.push(
                 	tagValue ? {label: $(this).text(), value: tagValue} : $(this).text()
                 );
@@ -209,7 +209,9 @@
             };
 
             if (this.options.select) {
-                this.element.after('<select class="tagit-hiddenSelect" name="'+this.element.attr('name')+'" multiple="multiple"></select>');
+                this.element.after('<select class="tagit-hiddenSelect" name="'+
+                    (this.element.attr('name') || this.element.data('name'))+
+                    '" multiple="multiple"></select>');
                 this.select = this.element.next('.tagit-hiddenSelect');
             }
             this._initialTags();


### PR DESCRIPTION
Some people may not want to use a `name` attribute on the `ul` or a `tagValue` attribute on the `li` tags, since neither is standard HTML. This patch allows use of `data-name` and `data-value` attributes instead, since such attributes are allowed in HTML5. The `name` and `tagValue` attributes will still work if they're present, so backward compatibility is maintained.
