### PR TITLE
Features: tagit-label and tags edit support

### DIFF
--- a/js/tagit-themeroller.js
+++ b/js/tagit-themeroller.js
@@ -91,6 +91,7 @@
             //true: entire tag is draggable
             //'handle': a handle is rendered which is draggable
             sortable:false,
+            editable:false,
             //color to highlight text when a duplicate tag is entered
             highlightOnExistColor:'#0F0',
             //empty search on focus
@@ -121,6 +122,8 @@
         _sortable:{
             sorting:-1
         },
+
+        _idEditing: false,
 
         //initialization function
         _create:function () {
@@ -175,9 +178,14 @@
                     self._popTag(tag);
                 }
                 else {
-                    self.input.focus();
+                    if (!self._isEditing) { //focus default input if we're not editing existing tag at the moment
+                        self.input.focus();
+                    }
                     if (self.options.emptySearch && $(e.target).hasClass('tagit-input') && self.input.val() == '' && self.input.autocomplete != undefined) {
                         self.input.autocomplete('search');
+                    }
+                    if (self.options.editable && $(e.target).hasClass('tagit-label')) {
+                        self._edit(e.target);
                     }
                 }
             });
@@ -312,6 +320,55 @@
 
         },
 
+        _postEdit: function(element, editInput, initialValue) {
+            var finishEditing = function() {
+                editInput.remove();
+                $(element).removeClass('hidden');
+                $(element).parent().removeClass('edited');
+                this._isEditing = false;
+            };
+
+            return function() {
+                var initialTagIndex = $(element).parent().index();
+                var initialTag = this.tagsArray[initialTagIndex];
+                //try to add new and if success - remove old
+                var newValue = editInput.val();
+                if (this._splitAt && newValue.search(this._splitAt) > 0) {
+                    newValue = newValue.split(this._splitAt)[0]; //use only first value part - no splitters in edit
+                }
+                if (newValue == initialValue) {
+                    finishEditing();
+                } else if (this._addTag(newValue)) {
+                    //else attempt to add new tag and if succeeded - remove old element and edit box
+                    initialTag.element.remove();
+                    this._popTag(initialTag);
+                    var lastTag = this.tagsArray[this.tagsArray.length - 1];
+                    //visually move tag to the old place
+                    lastTag.element.insertBefore(this.tagsArray[initialTagIndex].element);
+                    this._moveTag(this.tagsArray.length - 1, initialTagIndex); //move element from last to old place
+                    if(this.options.tagsChanged) { //fire an update
+                        var tag = this.tagsArray[initialTagIndex];
+                        this.options.tagsChanged(tag.value, 'moved', tag.element);
+                    }
+                    finishEditing();
+                }
+            }
+        },
+
+        _edit: function(element) {
+            this._isEditing = true;
+            var initialValue = $(element).text();
+            var editInput = $('<input>');
+            editInput.val(initialValue);
+            $(element).parent().addClass('edited');
+            editInput.addClass('tagit-edit');
+            editInput.css('width', $(element).outerWidth());
+            $(element).addClass('hidden');
+            editInput.blur($.proxy(this._postEdit(element, editInput, initialValue), this));
+            $(element).before(editInput);
+            editInput[0].select();
+        },
+
         _popSelect:function (tag) {
             $('option:eq(' + tag.index + ')', this.select).remove();
             this.select.change();
@@ -338,7 +395,7 @@
             if (this.options.select)
                 this._popSelect(tag);
             if (this.options.tagsChanged)
-                this.options.tagsChanged(tag.value || tag.label, 'popped', tag);
+                this.options.tagsChanged(tag? (tag.value || tag.label) : null, 'popped', tag);
             return;
         },
 
@@ -372,7 +429,7 @@
             tag.element = $('<li class="tagit-choice ui-widget-content ui-state-default"'
                 + (value !== undefined ? ' tagValue="' + value + '"' : '') + '>'
                 + (this.options.sortable == 'handle' ? '<a class="ui-icon ui-icon-grip-dotted-vertical" style="float:left"></a>' : '')
-                + label + '<a class="tagit-close ui-state-error-text">x</a></li>');
+                + '<div class="tagit-label">' + label + '</div>' + '<a class="tagit-close ui-state-error-text">x</a></li>');
             tag.element.insertBefore(this.input.parent());
             this.tagsArray.push(tag);
 
@@ -413,7 +470,10 @@
             tag.element.stop();
 
             var initialColor = tag.element.css('color');
-            tag.element.animate({color:this.options.highlightOnExistColor}, 100).animate({'color':initialColor}, 800);
+            tag.element.animate({color:this.options.highlightOnExistColor}, 100).animate({'color':initialColor}, 800, null, function() {
+                //reset style to initial
+                tag.element.attr('style', '');
+            });
         },
 
         _isInitKey:function (keyCode) {

--- a/js/tagit.js
+++ b/js/tagit.js
@@ -92,6 +92,7 @@
             //true: entire tag is draggable
             //'handle': a handle is rendered which is draggable
             sortable:false,
+            editable:false,
             //color to highlight text when a duplicate tag is entered
             highlightOnExistColor:'#0F0',
             //empty search on focus
@@ -122,6 +123,8 @@
         _sortable:{
             sorting:-1
         },
+
+        _idEditing: false,
 
         //initialization function
         _create:function () {
@@ -178,9 +181,14 @@
                     self._popTag(tag);
                 }
                 else {
-                    self.input.focus();
+                    if (!self._isEditing) { //focus default input if we're not editing existing tag at the moment
+                        self.input.focus();
+                    }
                     if (self.options.emptySearch && $(e.target).hasClass('tagit-input') && self.input.val() == '' && self.input.autocomplete != undefined) {
                         self.input.autocomplete('search');
+                    }
+                    if (self.options.editable && $(e.target).hasClass('tagit-label')) {
+                        self._edit(e.target);
                     }
                 }
             });
@@ -314,6 +322,55 @@
 
         },
 
+        _postEdit: function(element, editInput, initialValue) {
+            var finishEditing = function() {
+                editInput.remove();
+                $(element).removeClass('hidden');
+                $(element).parent().removeClass('edited');
+                this._isEditing = false;
+            };
+
+            return function() {
+                var initialTagIndex = $(element).parent().index();
+                var initialTag = this.tagsArray[initialTagIndex];
+                //try to add new and if success - remove old
+                var newValue = editInput.val();
+                if (this._splitAt && newValue.search(this._splitAt) > 0) {
+                    newValue = newValue.split(this._splitAt)[0]; //use only first value part - no splitters in edit
+                }
+                if (newValue == initialValue) {
+                    finishEditing();
+                } else if (this._addTag(newValue)) {
+                    //else attempt to add new tag and if succeeded - remove old element and edit box
+                    initialTag.element.remove();
+                    this._popTag(initialTag);
+                    var lastTag = this.tagsArray[this.tagsArray.length - 1];
+                    //visually move tag to the old place
+                    lastTag.element.insertBefore(this.tagsArray[initialTagIndex].element);
+                    this._moveTag(this.tagsArray.length - 1, initialTagIndex); //move element from last to old place
+                    if(this.options.tagsChanged) { //fire an update
+                        var tag = this.tagsArray[initialTagIndex];
+                        this.options.tagsChanged(tag.value, 'moved', tag.element);
+                    }
+                    finishEditing();
+                }
+            }
+        },
+
+        _edit: function(element) {
+            this._isEditing = true;
+            var initialValue = $(element).text();
+            var editInput = $('<input>');
+            editInput.val(initialValue);
+            $(element).parent().addClass('edited');
+            editInput.addClass('tagit-edit');
+            editInput.css('width', $(element).outerWidth());
+            $(element).addClass('hidden');
+            editInput.blur($.proxy(this._postEdit(element, editInput, initialValue), this));
+            $(element).before(editInput);
+            editInput[0].select();
+        },
+
         _popSelect:function (tag) {
             $('option:eq(' + tag.index + ')', this.select).remove();
             this.select.change();
@@ -374,7 +431,7 @@
             tag.element = $('<li class="tagit-choice"'
                 + (value !== undefined ? ' tagValue="' + value + '"' : '') + '>'
                 + (this.options.sortable == 'handle' ? '<a class="ui-icon ui-icon-grip-dotted-vertical" style="float:left"></a>' : '')
-                + label + '<a class="tagit-close">x</a></li>');
+                + '<div class="tagit-label">' + label + '</div>' + '<a class="tagit-close">x</a></li>');
             tag.element.insertBefore(this.input.parent());
             this.tagsArray.push(tag);
 
@@ -415,7 +472,10 @@
             tag.element.stop();
 
             var initialColor = tag.element.css('color');
-            tag.element.animate({color:this.options.highlightOnExistColor}, 100).animate({'color':initialColor}, 800);
+            tag.element.animate({color:this.options.highlightOnExistColor}, 100).animate({'color':initialColor}, 800, null, function() {
+                //reset style to initial
+                tag.element.attr('style', '');
+            });
         },
 
         _isInitKey:function (keyCode) {


### PR DESCRIPTION
Details:

small fixes:
1. 'style' is now cleared after highlight animation, so it no longer messes with other things you want to style.

features:
1. each tag label is now marked as 'tagit-label' class - simplifies use of ellipsis for tags and etc.
2. option 'editable', methods _edit and _postEdit were added

Edit logic:
if 'editable=true' click on a tag:
- hides corresponding tagit-label using class 'hidden'
- adds an input with class 'tagit-edit' and width of hidden tagit-label.
- adds 'edited' class to parent 'tagit-choice'
- selects tag label text in added input by call to .select()
  'blur' call of that added input:
- uses only first available value - line is splitted with _splitAt and first value is used
- if value is identical to old tag label - editing finished, nothing changed, all inputs and classes removed
- otherwise tries to add a new tag with _addTag. If fails (eg. tag with same value already exists) - stays at edit state
- if _addTag succeeds:
  - new tag is added at the end of tagsArray
  - removes old tag with _popTag and removes corresponding DOM element
  - moves last added tag to the place where old tag was with 'insertBefore' and _moveTag
  - fires 'tagsChanged' if it's present
  - finished editing process by removing inputs and classes like 'edited' and 'hidden'

Anyway, all this is in code, some comments were also added.
With lots of css changes for tagit in my project I wasn't able to add sample styles for: 'tagit-edit', 'hidden', 'edited', 'tagit-label'
I hope you will figure our yourself how to style these parts.

Changes were also added to tagit-themeroller, although weren't tested, so be careful when using.
