### PR TITLE
Features: tagit-label and tags edit support

### DIFF
--- a/js/tagit-themeroller.js
+++ b/js/tagit-themeroller.js
@@ -342,6 +342,7 @@
                     //else attempt to add new tag and if succeeded - remove old element and edit box
                     initialTag.element.remove();
                     this._popTag(initialTag);
+                    var lastTagIndex = this.tagsArray.length - 1;
                     if (lastTagIndex != initialTagIndex) {
                         var lastTag = this.tagsArray[lastTagIndex];
                         //visually move tag to the old place
@@ -565,6 +566,7 @@
 
         destroy:function () {
             $.Widget.prototype.destroy.apply(this, arguments); // default destroy
+            clearTimeout(this.timer);
             this.tagsArray = [];
         },
 

--- a/js/tagit.js
+++ b/js/tagit.js
@@ -342,6 +342,7 @@
                     //else attempt to add new tag and if succeeded - remove old element and edit box
                     initialTag.element.remove();
                     this._popTag(initialTag);
+                    var lastTagIndex = this.tagsArray.length - 1;
                     if (lastTagIndex != initialTagIndex) {
                         var lastTag = this.tagsArray[lastTagIndex];
                         //visually move tag to the old place
@@ -565,6 +566,7 @@
 
         destroy:function () {
             $.Widget.prototype.destroy.apply(this, arguments); // default destroy
+            clearTimeout(this.timer);
             this.tagsArray = [];
         },
 


### PR DESCRIPTION
Implemented tags edit feature, added a couple of fixes.
Details:

small fixes:
1. 'style' is now cleared after highlight animation, so it no longer messes with other things you want to style.

features:
1. each tag label is now marked as 'tagit-label' class - simplifies use of ellipsis for tags and etc.
2. option 'editable', methods _edit and _postEdit were added

Edit logic:
if 'editable=true' click on a tag:
- hides corresponding tagit-label using class 'hidden'
- adds an input with class 'tagit-edit' and width of hidden tagit-label.
- adds 'edited' class to parent 'tagit-choice'
- selects tag label text in added input by call to .select()
  'blur' call of that added input:
- uses only first available value - line is splitted with _splitAt and first value is used
- if value is identical to old tag label - editing finished, nothing changed, all inputs and classes removed
- otherwise tries to add a new tag with _addTag. If fails (eg. tag with same value already exists) - stays at edit state
- if _addTag succeeds:
  - new tag is added at the end of tagsArray
  - removes old tag with _popTag and removes corresponding DOM element
  - moves last added tag to the place where old tag was with 'insertBefore' and _moveTag
  - fires 'tagsChanged' if it's present
  - finished editing process by removing inputs and classes like 'edited' and 'hidden'

Anyway, all this is in code, some comments were also added.
With lots of css changes for tagit in my project I wasn't able to add sample styles for: 'tagit-edit', 'hidden', 'edited', 'tagit-label'
I hope you will figure our yourself how to style these parts.

Changes were also added to tagit-themeroller, although weren't tested, so be careful when using.
