### PR TITLE
jQuery 1.8.2 & jQueryUI 1.9.2 fail when adding option ...,select:true,...

### DIFF
--- a/js/tagit.js
+++ b/js/tagit.js
@@ -3,6 +3,8 @@
  * ---------------------------
  * Owner:     jquery.webspirited.com
  * Developer: Matthew Hailwood
+ * Patches:   Alban Crommer
+ * Source:    https://github.com/albancrommer/jQuery-Tagit
  * ---------------------------
  */
 
@@ -71,7 +73,7 @@
     $.widget("ui.tagit", {
 
         // default options
-        options:{
+        options: {
             //Maps directly to the jQuery-ui Autocomplete option
             tagSource:[],
             //What keys should trigger the completion of a tag
@@ -127,9 +129,9 @@
         _create:function () {
 
             var self = this;
+            this.options.initialTags = [] // Force reinit
             this.tagsArray = [];
             this.timer = null;
-
             //add class "tagit" for theming
             this.element.addClass("tagit");
 
@@ -461,7 +463,6 @@
             if (this.options.tagsChanged)
                 _temp = this.options.tagsChanged;
             this.options.tagsChanged = null;
-
             if (this.options.initialTags.length != 0) {
                 $(this.options.initialTags).each(function (i, element) {
                     if (typeof (element) == "object")
@@ -501,6 +502,7 @@
         destroy:function () {
             $.Widget.prototype.destroy.apply(this, arguments); // default destroy
             this.tagsArray = [];
+
         },
 
         reset:function () {


### PR DESCRIPTION
Backtracked it to focus event not receiving anymore an imbricated originalEvent.originalEvent but a simple originalEvent

Hence this minor fix to allow working with both.
