### PR TITLE
clear initialTags on _create 

### DIFF
--- a/js/tagit.js
+++ b/js/tagit.js
@@ -130,7 +130,7 @@
             this.tagsArray = [];
             this.timer = null;
             this.lastKey = 0;
-
+            self.options.initialTags=[];
             //add class "tagit" for theming
             this.element.addClass("tagit");
 


### PR DESCRIPTION
Clear initialTags array on _create to allow for multiple instances of tagit to be pre-populated.
