### PR TITLE
Remove call to console.log

### DIFF
--- a/js/tagit-themeroller.js
+++ b/js/tagit-themeroller.js
@@ -308,7 +308,6 @@
             }
 
             var pressedKey = e.which || e.keyCode || e.charCode;
-            console.log("processKeyEvent:" + pressedKey);
             var lastLi = this.element.children(".tagit-choice:last");
 
             this.isKeyEventProcessed = true;

--- a/js/tagit.js
+++ b/js/tagit.js
@@ -310,7 +310,6 @@
             }
 
             var pressedKey = e.which || e.keyCode || e.charCode;
-            console.log("processKeyEvent:" + pressedKey);
             var lastLi = this.element.children(".tagit-choice:last");
 
             this.isKeyEventProcessed = true;


### PR DESCRIPTION
Calling console.log function in older versions of IE results in an
exception being thrown, since they don't have a native support of this
functionality.

Fixes #77
