### PR TITLE
Minor fixes - undefined categories and event when tags are inited.

### DIFF
--- a/js/tagit-themeroller.js
+++ b/js/tagit-themeroller.js
@@ -74,7 +74,7 @@
             var that = this,
                 currentCategory = "";
             $.each( items, function( index, item ) {
-                if ( item.category != currentCategory ) {
+                if ( item.category && item.category != currentCategory ) {
                     ul.append( "<li class='ui-autocomplete-category'>" + item.category + "</li>" );
                     currentCategory = item.category;
                 }
@@ -582,6 +582,7 @@
                 });
             }
             this.options.tagsChanged = _temp;
+            this.options.tagsChanged(null, 'tagsInited', null);
         },
 
         _lowerIfCaseInsensitive:function (inp) {

--- a/js/tagit.js
+++ b/js/tagit.js
@@ -73,7 +73,7 @@
             var that = this,
                 currentCategory = "";
             $.each( items, function( index, item ) {
-                if ( item.category != currentCategory ) {
+                if ( item.category && item.category != currentCategory ) {
                     ul.append( "<li class='ui-autocomplete-category'>" + item.category + "</li>" );
                     currentCategory = item.category;
                 }
@@ -584,6 +584,7 @@
                 });
             }
             this.options.tagsChanged = _temp;
+            this.options.tagsChanged(null, 'tagsInited', null);
         },
 
         _lowerIfCaseInsensitive:function (inp) {


### PR DESCRIPTION
Fix for 'undefined' categories in autocomplete
Added 'tagsInited' event to allow updates after initial tags are set. Usecase example - update page scroller after all tags are added
