### PR TITLE
Allow int values as labels

### DIFF
--- a/js/tagit-themeroller.js
+++ b/js/tagit-themeroller.js
@@ -475,6 +475,9 @@
             if (newTag.label === undefined) { //set label to value to simplify possible use-cases, eg. if we send data from server where title isn't set
                 newTag.label = newTag.value;
             }
+            if(newTag.label === parseInt(newTag.label, 10)){
+                    newTag.label=newTag.label.toString();
+            }
             this.input.catcomplete('close').val("");
 
             //are we trying to add a tag that should be split?

--- a/js/tagit.js
+++ b/js/tagit.js
@@ -476,6 +476,9 @@
             if (newTag.label === undefined) { //set label to value to simplify possible use-cases, eg. if we send data from server where title isn't set
                 newTag.label = newTag.value;
             }
+            if(newTag.label === parseInt(newTag.label, 10)){
+                    newTag.label=newTag.label.toString();
+            }
             this.input.catcomplete('close').val("");
 
             //are we trying to add a tag that should be split?


### PR DESCRIPTION
Allow int values as labels.

Whenever an int value is passed as a label there was a conflict with .search function.

If label is int we must convert it to string
